### PR TITLE
Fix class QButtonGroup include errors with Qt 5.11

### DIFF
--- a/src/paletteeditor.cpp
+++ b/src/paletteeditor.cpp
@@ -20,6 +20,7 @@
 #include <QFileDialog>
 #include <QSettings>
 #include <QLinearGradient>
+#include <QButtonGroup>
 
 #include "paletteeditor.h"
 #include "flam3util.h"

--- a/src/trianglecoordswidget.cpp
+++ b/src/trianglecoordswidget.cpp
@@ -16,6 +16,7 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  ***************************************************************************/
 #include <QSettings>
+#include <QButtonGroup>
 
 #include "flam3util.h"
 #include "trianglecoordswidget.h"

--- a/src/triangledensitywidget.cpp
+++ b/src/triangledensitywidget.cpp
@@ -16,6 +16,7 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  ***************************************************************************/
 #include <QVBoxLayout>
+#include <QButtonGroup>
 
 #include "triangledensitywidget.h"
 #include "selecttrianglewidget.h"


### PR DESCRIPTION
This patch fixes the following error:

<pre><code>
src/paletteeditor.cpp: In constructor ‘PaletteEditor::PaletteEditor(QWidget*)’:
src/paletteeditor.cpp:44:47: error: invalid use of incomplete type ‘class QButtonGroup’
  m_gradientSpreadGroup = new QButtonGroup(this);
                                               ^
In file included from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qradiobutton.h:44,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QRadioButton:1,
                 from .ui/ui_paletteeditor.h:22,
                 from src/paletteeditor.h:29,
                 from src/paletteeditor.cpp:24:
/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qabstractbutton.h:53:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
[...]
</code></pre>

It seems that with Qt5 in version 5.11 does not implicitly pull the
QButtonGroup definition through some other include. Therefore we need to
explicitly include it.