### PR TITLE
Fix Lua 5.2 include directory

### DIFF
--- a/qosmic.pro
+++ b/qosmic.pro
@@ -38,16 +38,16 @@ CONFIG += install_icons install_desktop install_scripts
 
 link_pkgconfig {
 	message("Config using pkg-config version "$$system(pkg-config --version))
-	PKGCONFIG = flam3 lua
+	PKGCONFIG = flam3 lua5.2
 }
 else {
 	message("Config not using pkg-config")
 	## Adjust these variables to set paths and libs without using pkg-config.
 	## Point to the flam3-3.1.1 source directory
 	FLAM3_SRC_DIR = $$system(readlink -e ../flam3-3.1.1)
-	INCLUDEPATH += $$FLAM3_SRC_DIR /usr/include/libxml2
+	INCLUDEPATH += $$FLAM3_SRC_DIR /usr/include/libxml2 /usr/include/lua5.2/
 	LIBS += -L$$FLAM3_SRC_DIR/.libs
-	LIBS += -L/usr/lib/libxml2 -lflam3 -lm -ljpeg -lxml2 -llua
+	LIBS += -L/usr/lib/libxml2 -lflam3 -lm -ljpeg -lxml2 -llua5.2
 }
 
 


### PR DESCRIPTION
In Linux distributions Lua 5.2 is usually provided in a namespace
which includes the version number. This results in the following build
errors on Debian for instance:

<pre><code>
In file included from src/lua/luathread.h:24,
                 from src/scripteditwidget.h:22,
                 from src/mainwindow.h:39,
                 from src/qosmic.cpp:25:
src/lua/lunar.h:12:10: fatal error: lua.h: No such file or directory
 #include "lua.h"
          ^~~~~~~
compilation terminated.
make: *** [Makefile:1773: .obj/qosmic.o] Error 1
</code></pre>

This patch fixes such erros by using "lua5.2" instead of just "lua" for
the include path.

It seems that on Gentoo (#32) and Linux Mint (#31) the same issue is
present.