### PR TITLE
Removed custom colors for the Variations panel

### DIFF
--- a/src/varstablewidget.cpp
+++ b/src/varstablewidget.cpp
@@ -362,7 +362,7 @@ VarsTableItem* VarsTableItem::parent()
 // -----------------------------------------------------------------------------
 
 VarsTableModel::VarsTableModel(QObject* parent) : QAbstractItemModel(parent),
-	decimals(2), activeColor(QColor(200,230,240)), inactiveColor(Qt::white)
+	decimals(2)
 {
 	QList<QVariant> itemData;
 	itemData << tr("Variation") << tr("Value") << " ";
@@ -456,14 +456,6 @@ QVariant VarsTableModel::data(const QModelIndex& index, int role) const
 		{
 			VarsTableItem* item = static_cast<VarsTableItem*>(index.internalPointer());
 			return item->data(index.column());
-		}
-		case Qt::BackgroundRole:
-		{
-			VarsTableItem* item = static_cast<VarsTableItem*>(index.internalPointer());
-			if (index.column() == 1 && item->data(1).toDouble() != 0.0)
-				return activeColor;
-			else
-				return inactiveColor;
 		}
 	}
 	return QVariant();

--- a/src/varstablewidget.h
+++ b/src/varstablewidget.h
@@ -50,8 +50,6 @@ class VarsTableModel : public QAbstractItemModel
 	VarsTableItem* rootItem;
 	flam3_xform* xform;
 	int decimals;
-	const QBrush activeColor;
-	const QBrush inactiveColor;
 	QMap<QString, VarsTableItem*> variationItems;
 
 	public:


### PR DESCRIPTION
There was some custom code to change the background color of the cells if the value was different than zero.

However, for some reason I don't understand (and I don't want to investigate deeper), this logic doesn't work well, and the background seems the same regardless of the value.

To make it worse, since only the background is changed, the text becomes unreadable if the user is using a dark theme for the desktop environment. See #45.

This commit removes this custom logic. I don't think it's bringing any value (since it's not working for me, the color is always the same) and it is causing issues. The removal of this logic makes this panel follow the user's theme, which makes the application look nicer and more cohesive.

Fixes #45.